### PR TITLE
Updated deprecated API

### DIFF
--- a/src/main/java/no/fint/ApplicationSecurity.java
+++ b/src/main/java/no/fint/ApplicationSecurity.java
@@ -1,15 +1,15 @@
 package no.fint;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 
 @Configuration
-public class ApplicationSecurity extends WebSecurityConfigurerAdapter {
+public class ApplicationSecurity {
 
-    @Override
-    public void configure(WebSecurity web) {
-        web
+    @Bean
+    public WebSecurityCustomizer configure() {
+        return web -> web
                 .ignoring()
                 .antMatchers("/**");
     }


### PR DESCRIPTION
Denne endringen trengs fordi i fremtidige spring versjoner 2.7.0+ så er WebSecurityConfigurerAdapter deprecated. Det anbefales av spring å eksponere bønne av WebSecurityCustomizer, som er gjort her.

Jeg får kompilert og kjørt applikasjonen, men jeg vet ikke hvordan jeg kan få testet det som har blitt endret. Så kanskje du kan se om det fremdeles fungerer @fsjovatsen 